### PR TITLE
Updated advanced options will be used in the translation job for DWG/RVT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "derivative-service-node.js-sample",
+  "name": "aps-buckets-tools",
   "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "derivative-service-node.js-sample",
+      "name": "aps-buckets-tools",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Updated advanced options will be used in the translation job for DWG, DXF, and RVT files to generate 2D views as PDFs.
### Objective:  
Drawings with large datasets often fail to translate with the legacy pipeline. This submission updates the Model Translation to use a modern DWG-to-PDF translation pipeline for 2D Views. The submission also addresses Revit files, applying the modern pipeline to Revit files version 2022 and later. For previous versions, there is no change in behavior; the legacy translation pipeline will continue to be used.

Ref: https://aps.autodesk.com/blog/advanced-option-rvtdwg-2d-views-svf2-post-job
### Testing:
- Manually uploaded a Revit 2021 version, and the legacy translation pipeline was used.
- Manually uploaded a Revit 2022 version, and the modern translation pipeline was used.
- Manually uploaded a drawing file within an archive, and the modern translation pipeline was used.

![rvt2021-Test](https://github.com/user-attachments/assets/0f75f754-3968-4a0c-88e3-0f4319e514b5)

![rvt2022-test](https://github.com/user-attachments/assets/6a8d001f-54a4-4eeb-a213-309fbb508e88)

![dwg test](https://github.com/user-attachments/assets/5b42267a-d85e-4cca-810e-94a550fe7f86)
